### PR TITLE
chore: Estrutura base do Docker com variáveis de ambiente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Database
+POSTGRES_USER=estaciona
+POSTGRES_PASSWORD=yourSuperSecretPassword
+POSTGRES_DB=estaciona_ai
+
+# Server Config
+DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}

--- a/infra/Dockerfile.server
+++ b/infra/Dockerfile.server
@@ -1,0 +1,3 @@
+FROM python:3.11-slim
+WORKDIR /app
+# TODO: Passos de build + dependências

--- a/infra/Dockerfile.vision
+++ b/infra/Dockerfile.vision
@@ -1,0 +1,3 @@
+FROM python:3.11-slim
+WORKDIR /app
+# TODO: Implementar passos de build

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: estaciona_db
+    env_file:
+      - ../.env.local
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - estaciona_net
+
+  server:
+    build:
+      context: ..
+      dockerfile: infra/Dockerfile.server
+    container_name: estaciona_server
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    env_file:
+      - ../.env
+    networks:
+      - estaciona_net
+
+  vision:
+    build:
+      context: ..
+      dockerfile: infra/Dockerfile.vision
+    container_name: estaciona_vision
+    depends_on:
+      - server
+    volumes:
+      - ../datasets:/app/datasets
+    networks:
+      - estaciona_net
+
+volumes:
+  postgres_data:
+
+networks:
+  estaciona_net:
+    driver: bridge
+    


### PR DESCRIPTION
Closes #5 . Estabelece a infraestrutura básica via Docker utilizando `.env` para proteção de credenciais. Prepara os serviços de banco de dados (PostgreSQL), servidor central e edge.