### PR TITLE
[test]: valida a lógica de reservas

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -14,4 +14,5 @@ dependencies = [
 dev = [
     "httpx>=0.28.1",
     "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
 ]

--- a/server/src/reservations.py
+++ b/server/src/reservations.py
@@ -39,7 +39,7 @@ class ReservationManager:
 
     async def cancel_reservation(self, reservation_id: UUID4) -> bool:
         reservation = self.active_reservations.get(reservation_id)
-        if not reservation_id:
+        if not reservation:
             return False
 
         spot_id = reservation["spot_id"]

--- a/server/tests/test_reservations.py
+++ b/server/tests/test_reservations.py
@@ -1,6 +1,5 @@
 import pytest
 import uuid
-import asyncio
 from src.state import ParkingState
 from src.reservations import ReservationManager
 

--- a/server/tests/test_reservations.py
+++ b/server/tests/test_reservations.py
@@ -12,3 +12,20 @@ def manager():
 @pytest.fixture
 def sample_user():
     return str(uuid.uuid4())
+
+@pytest.mark.asyncio  
+async def test_create_reservation_and_prevent_double_booking(manager, sample_user):
+    spot_id = "A-10"
+
+    # Primeira reserva deve funcionar
+    res1 = await manager.create_reservation(spot_id, sample_user, "ABC1234")
+    assert res1 is not None
+    assert res1["spot_id"] == spot_id
+    assert manager.state._spots[spot_id] == "reserved"
+
+    # Segunda reserva no mesmo spot deve falhar
+    user2 = str(uuid.uuid4())
+    res2 = await manager.create_reservation(spot_id, user2, "1234ABC")
+    assert res2 is None
+    
+    

--- a/server/tests/test_reservations.py
+++ b/server/tests/test_reservations.py
@@ -28,4 +28,23 @@ async def test_create_reservation_and_prevent_double_booking(manager, sample_use
     res2 = await manager.create_reservation(spot_id, user2, "1234ABC")
     assert res2 is None
     
+@pytest.mark.asyncio
+async def test_cancel_reservation(manager, sample_user):
+    spot_id = "B-05"
+    res = await manager.create_reservation(spot_id, sample_user, "ABC1234")
+
+    # Cancelamento válido
+    success = await manager.cancel_reservation(res["reservation_id"])
+    assert success is True
+    assert manager.state._spots[spot_id] == "free"
+    assert res["reservation_id"] not in manager.active_reservations
+
+    # Cancelamento de ID inexistente
+    fake_id = uuid.uuid4()
+    fail = await manager.cancel_reservation(fake_id)
+    assert fail is False
+
+
+
+    
     

--- a/server/tests/test_reservations.py
+++ b/server/tests/test_reservations.py
@@ -1,49 +1,104 @@
 import pytest
+import asyncio
 import uuid
+from unittest.mock import patch, AsyncMock
 from src.state import ParkingState
 from src.reservations import ReservationManager
+
 
 @pytest.fixture
 def manager():
     state = ParkingState()
     return ReservationManager(state)
 
+
 @pytest.fixture
 def sample_user():
     return str(uuid.uuid4())
 
-@pytest.mark.asyncio  
+
+async def _cancel_pending_tasks():
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    for t in pending:
+        t.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_create_reservation_and_prevent_double_booking(manager, sample_user):
     spot_id = "A-10"
 
-    # Primeira reserva deve funcionar
-    res1 = await manager.create_reservation(spot_id, sample_user, "ABC1234")
-    assert res1 is not None
-    assert res1["spot_id"] == spot_id
-    assert manager.state._spots[spot_id] == "reserved"
+    with patch.object(ReservationManager, "_schedule_expiration", new_callable=AsyncMock):
+        # Primeira reserva deve funcionar
+        res1 = await manager.create_reservation(spot_id, sample_user, "ABC1234")
+        assert res1 is not None
+        assert res1["spot_id"] == spot_id
+        assert manager.state._spots[spot_id] == "reserved"
 
-    # Segunda reserva no mesmo spot deve falhar
+        # Segunda reserva no mesmo spot deve falhar
+        user2 = str(uuid.uuid4())
+        res2 = await manager.create_reservation(spot_id, user2, "1234ABC")
+        assert res2 is None
+
+        await _cancel_pending_tasks()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reservation_prevention(manager):
+    spot_id = "C-01"
+    user1 = str(uuid.uuid4())
     user2 = str(uuid.uuid4())
-    res2 = await manager.create_reservation(spot_id, user2, "1234ABC")
-    assert res2 is None
-    
+
+    # Mocking _schedule_expiration prevents the expiration task from freeing
+    # the spot between the two concurrent create_reservation calls, keeping
+    # the test focused on the lock-based concurrency control.
+    with patch.object(ReservationManager, "_schedule_expiration", new_callable=AsyncMock):
+        res1, res2 = await asyncio.gather(
+            manager.create_reservation(spot_id, user1, "AAA0001"),
+            manager.create_reservation(spot_id, user2, "BBB0002"),
+        )
+
+        # Exatamente uma deve ter sucesso e o spot permanecer "reserved"
+        assert sum(1 for r in (res1, res2) if r is not None) == 1
+        assert manager.state._spots[spot_id] == "reserved"
+
+        await _cancel_pending_tasks()
+
+
 @pytest.mark.asyncio
 async def test_cancel_reservation(manager, sample_user):
     spot_id = "B-05"
-    res = await manager.create_reservation(spot_id, sample_user, "ABC1234")
 
-    # Cancelamento válido
-    success = await manager.cancel_reservation(res["reservation_id"])
-    assert success is True
-    assert manager.state._spots[spot_id] == "free"
-    assert res["reservation_id"] not in manager.active_reservations
+    with patch.object(ReservationManager, "_schedule_expiration", new_callable=AsyncMock):
+        res = await manager.create_reservation(spot_id, sample_user, "ABC1234")
 
-    # Cancelamento de ID inexistente
-    fake_id = uuid.uuid4()
-    fail = await manager.cancel_reservation(fake_id)
-    assert fail is False
+        # Cancelamento válido
+        success = await manager.cancel_reservation(res["reservation_id"])
+        assert success is True
+        assert manager.state._spots[spot_id] == "free"
+        assert res["reservation_id"] not in manager.active_reservations
+
+        # Cancelamento de ID inexistente
+        fake_id = uuid.uuid4()
+        fail = await manager.cancel_reservation(fake_id)
+        assert fail is False
+
+        await _cancel_pending_tasks()
 
 
+@pytest.mark.asyncio
+async def test_reservation_expiration(manager, sample_user):
+    spot_id = "D-03"
 
-    
-    
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        res = await manager.create_reservation(spot_id, sample_user, "EXP1234")
+        assert res is not None
+        assert manager.state._spots[spot_id] == "reserved"
+
+        # Aguarda a conclusão da tarefa de expiração (sleep mockado retorna imediatamente)
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        await asyncio.gather(*pending, return_exceptions=True)
+
+        mock_sleep.assert_called_once_with(30 * 60)
+        assert manager.state._spots[spot_id] == "free"
+        assert res["reservation_id"] not in manager.active_reservations

--- a/server/tests/test_reservations.py
+++ b/server/tests/test_reservations.py
@@ -1,0 +1,14 @@
+import pytest
+import uuid
+import asyncio
+from src.state import ParkingState
+from src.reservations import ReservationManager
+
+@pytest.fixture
+def manager():
+    state = ParkingState()
+    return ReservationManager(state)
+
+@pytest.fixture
+def sample_user():
+    return str(uuid.uuid4())

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -78,6 +78,7 @@ dependencies = [
 dev = [
     { name = "httpx" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -92,6 +93,7 @@ requires-dist = [
 dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]
 
 [[package]]
@@ -318,6 +320,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Valida a lógica de reservas do servidor com testes automatizados, cobrindo criação, prevenção de double-booking, concorrência, cancelamento e expiração automática.

## Changes Made

- **`pytest-asyncio`**: adicionado como dependência de desenvolvimento para suportar testes `async`.
- **`server/tests/test_reservations.py`**: suíte de testes para o `ReservationManager` com:
  - `test_create_reservation_and_prevent_double_booking`: valida criação de reserva e rejeição de tentativas duplicadas no mesmo spot.
  - `test_concurrent_reservation_prevention`: dispara duas `create_reservation` concorrentes via `asyncio.gather` para o mesmo spot, assegurando que o lock garante que apenas uma tenha sucesso.
  - `test_cancel_reservation`: valida o cancelamento correto e a rejeição de IDs inexistentes.
  - `test_reservation_expiration`: usa `patch("asyncio.sleep", AsyncMock)` para que `_schedule_expiration` complete imediatamente, verificando que o spot é liberado e a reserva removida de `active_reservations`.
  - Todos os testes cancelam tarefas pendentes ao final via `_cancel_pending_tasks()`, evitando avisos no teardown do event loop.
- **`server/src/reservations.py`**: corrige `cancel_reservation` para retornar `False` quando a reserva não existe.

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
