### PR TITLE
Endpoints REST, centralização de estado e testes automatizados

### DIFF
--- a/server/src/dependencies.py
+++ b/server/src/dependencies.py
@@ -1,0 +1,11 @@
+from .state import ParkingState
+from .reservations import ReservationManager
+
+parking_state = ParkingState()
+reservation_manager = ReservationManager(parking_state)
+
+def get_parking_state() -> ParkingState:
+    return parking_state
+
+def get_reservation_manager() -> ReservationManager:
+    return reservation_manager

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from .ws_app import router as app_router
 from .ws_edge import router as edge_router
+from .routes import router as routes_router
 
 app = FastAPI(
     title="Estaciona AI Server",
@@ -10,6 +11,7 @@ app = FastAPI(
 
 app.include_router(app_router)
 app.include_router(edge_router)
+app.include_router(routes_router)
 
 @app.get("/health")
 async def health_check():

--- a/server/src/routes.py
+++ b/server/src/routes.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, HTTPException, Depends, status
+from pydantic import UUID4
+from typing import Dict
+from .models import ReserveSpotApp, ReservationConfirmedServer
+from .reservations import ReservationManager
+from .state import ParkingState
+from .dependencies import get_reservation_manager, get_parking_state
+
+router = APIRouter()
+
+@router.post("/reservations", response_model=ReservationConfirmedServer, status_code=status.HTTP_201_CREATED)
+async def create_reservation(
+    payload: ReserveSpotApp,
+    manager: ReservationManager = Depends(get_reservation_manager)
+):
+    reservation = await manager.create_reservation(payload.spot_id, payload.user_id, payload.plate)
+    if not reservation:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Spot already taken or invalid")
+
+    return ReservationConfirmedServer(
+        reservation_id=reservation["reservation_id"],
+        spot_id=reservation["spot_id"],
+        expires_at=reservation["expires_at"]
+    )
+
+@router.delete("/reservations/{reservation_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def cancel_reservation(
+    reservation_id: UUID4,
+    manager: ReservationManager = Depends(get_reservation_manager)
+):
+    success = await manager.cancel_reservation(reservation_id)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Reservation not found")
+
+@router.get("/spots", response_model=Dict[str, str])
+async def get_spots(state: ParkingState = Depends(get_parking_state)):
+    return state._spots
+
+    

--- a/server/src/ws_edge.py
+++ b/server/src/ws_edge.py
@@ -2,11 +2,10 @@ import json
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
 from .models import SpotUpdateServer, SpotUpdateEdge
-from .state import ParkingState
+from .dependencies import parking_state
 from .ws_app import manager
 
 router = APIRouter()
-parking_state = ParkingState()
 
 @router.websocket('/ws/edge')
 async def websocket_edge_endpoint(websocket: WebSocket):


### PR DESCRIPTION
Closes #29 . Cria as rotas `/reservations` (POST, DELETE) e `/spots` (GET). Centraliza o estado da aplicação em `dependencies.py` para compartilhamento seguro entre WebSocket e requisições HTTP REST. Valida tudo com testes automatizados.