### PR TITLE
Integração do PostgreSQL nas reservas e rotas

### DIFF
--- a/server/src/db.py
+++ b/server/src/db.py
@@ -1,6 +1,9 @@
 import asyncpg
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
+import os
+from pydantic import UUID4
+from datetime import datetime
 
 class Settings(BaseSettings):
     database_url: str = "sqlite+aiosqlite:///./test.db"
@@ -21,5 +24,40 @@ class Database:
     async def disconnect(self):
         if self.pool:
             await self.pool.close()
+
+    async def init_schema(self):
+        schema_path = os.path.join(os.path.dirname(__file__), '..', 'schema.sql')
+        with open(schema_path, 'r') as f:
+            schema = f.read()
+
+        async with self.pool.acquire() as conn:
+            await conn.execute(schema)
+
+    async def ensure_user_exists(self, user_id: str, plate: str):
+        query = """
+            INSERT INTO users (id, plate)
+            VALUES ($1, $2)
+            ON CONFLICT (id) DO NOTHING;
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute(query, user_id, plate)
+
+    async def save_reservation(self, res_id: UUID4, user_id: str, spot_id: str, expires_at: datetime):
+        query = """
+            INSERT INTO reservations (id, user_id, spot_id, status, expires_at)
+            VALUES ($1, $2, $3, 'active', $4);
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute(query, res_id, user_id, spot_id, expires_at)
+
+    async def update_reservation_status(self, res_id: UUID4, status: str):
+        query = """
+            UPDATE reservations
+            SET status = $1,
+                completed_at = CASE WHEN $1 IN ('completed', 'expired') THEN NOW() ELSE completed_at END
+            WHERE id = $2;
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute(query, status, res_id)
 
 db = Database()

--- a/server/src/dependencies.py
+++ b/server/src/dependencies.py
@@ -1,8 +1,9 @@
 from .state import ParkingState
 from .reservations import ReservationManager
+from .db import db
 
 parking_state = ParkingState()
-reservation_manager = ReservationManager(parking_state)
+reservation_manager = ReservationManager(parking_state, db)
 
 def get_parking_state() -> ParkingState:
     return parking_state

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await db.connect()
+    await db.init_schema()
     yield
     await db.disconnect()
 

--- a/server/src/reservations.py
+++ b/server/src/reservations.py
@@ -4,10 +4,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 from pydantic import UUID4
 from .state import ParkingState
+from .db import Database
 
 class ReservationManager:
-    def __init__(self, parking_state: ParkingState):
+    def __init__(self, parking_state: ParkingState, db: Database):
         self.state = parking_state
+        self.db = db
         self.active_reservations: Dict[UUID4, dict] = {}
         
     async def create_reservation(self, spot_id: str, user_id: str, plate: str) -> Optional[dict]:
@@ -31,6 +33,9 @@ class ReservationManager:
             }
 
             self.active_reservations[res_id] = reservation
+
+            await self.db.ensure_user_exists(user_id, plate)
+            await self.db.save_reservation(res_id, user_id, spot_id, expires_at)
             
             # Schedule cleanup task
             asyncio.create_task(self._schedule_expiration(res_id, spot_id))
@@ -47,6 +52,7 @@ class ReservationManager:
             # Grants that only if the state is still "reserved"
             if self.state._spots.get(spot_id) == "reserved":
                 self.state._spots[spot_id] = "free"
+                await self.db.update_reservation_status(reservation_id, "cancelled")
             
             self.active_reservations.pop(reservation_id, None)
             return True
@@ -58,7 +64,7 @@ class ReservationManager:
             if res_id in self.active_reservations:
                 if self.state._spots.get(spot_id) == "reserved":
                     self.state._spots[spot_id] = "free"
-                    # TODO: Notify user about the expiration
+                    await self.db.update_reservation_status(res_id, "expired")              
             
                 self.active_reservations.pop(res_id, None)
 

--- a/server/tests/test_reservations.py
+++ b/server/tests/test_reservations.py
@@ -1,15 +1,23 @@
 import pytest
 import asyncio
 import uuid
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 from src.state import ParkingState
 from src.reservations import ReservationManager
 
-
 @pytest.fixture
-def manager():
+def mock_db():
+    db = MagicMock()
+    db.ensure_user_exists = AsyncMock()
+    db.save_reservation = AsyncMock()
+    db.update_reservation_status = AsyncMock()
+    return db
+
+    
+@pytest.fixture
+def manager(mock_db):
     state = ParkingState()
-    return ReservationManager(state)
+    return ReservationManager(state, mock_db)
 
 
 @pytest.fixture

--- a/server/tests/test_routes.py
+++ b/server/tests/test_routes.py
@@ -31,7 +31,12 @@ async def test_create_reservation_endpoint():
         "plate": "ABC-1234",
     }
 
-    with patch("src.reservations.ReservationManager._schedule_expiration", new_callable=AsyncMock):
+    with (
+        patch("src.reservations.ReservationManager._schedule_expiration", new_callable=AsyncMock),
+        patch("src.db.db.ensure_user_exists", new_callable=AsyncMock),
+        patch("src.db.db.save_reservation", new_callable=AsyncMock),
+        patch("src.db.db.update_reservation_status", new_callable=AsyncMock),
+    ):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.post("/reservations", json=payload)
             assert response.status_code == 201
@@ -51,7 +56,12 @@ async def test_cancel_reservation_endpoint():
     spot_id = "A-02"
     user_id = str(uuid.uuid4())
 
-    with patch("src.reservations.ReservationManager._schedule_expiration", new_callable=AsyncMock):
+    with (
+        patch("src.reservations.ReservationManager._schedule_expiration", new_callable=AsyncMock),
+        patch("src.db.db.ensure_user_exists", new_callable=AsyncMock),
+        patch("src.db.db.save_reservation", new_callable=AsyncMock),
+        patch("src.db.db.update_reservation_status", new_callable=AsyncMock),
+    ):
         manager = get_reservation_manager()
         res = await manager.create_reservation(spot_id, uuid.UUID(user_id), "DEL1234")
         res_id = str(res["reservation_id"])


### PR DESCRIPTION
Closes #37 . Adiciona injeção da dependência `db` no `ReservationManager`. Implementa a persistência assíncrona para criação e cancelamento/expiração de reservas, garantindo o histórico. Atualiza a suite de testes com `AsyncMock` para isolamento do banco.